### PR TITLE
Support strict mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,9 @@ const provide = function (options) {
 var rollupEnv = ${optionsStr};
 if (window && !window.process) {
   window.process = {};
-} else if (!process) {
-  var process = {};
+}
+if (!process) {
+  var process = window.process;
 }
 process.env = process.env || {};
 Object.keys(rollupEnv).forEach(function (prop) {


### PR DESCRIPTION
In strict mode, the variable 'process' in a function scope is not the one in 'window', it's not defined actually.
